### PR TITLE
Bump `compact-encoding` to `3.0.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "prettier-config-holepunch": "^2.0.0"
   },
   "dependencies": {
-    "compact-encoding": "^2.18.0",
+    "compact-encoding": "^3.0.0",
     "hyperschema": "^1.19.0",
     "protomux": "^3.10.1"
   }


### PR DESCRIPTION
Checked the schema and it doesnt include any `buffer`s or `binary`s so should be fine.

Depends on:

- https://github.com/holepunchto/hyperschema/pull/56
- https://github.com/holepunchto/protomux/pull/28 (being released)